### PR TITLE
add support for puppet 3.6.x and bump rev to 0.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.6.0"
 # Only notify for failed builds.
 notifications:
   email:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-06-18 Release 0.0.3
+- Add support for puppet 3.6.x
+
 2014-01-29 Release 0.0.2
 - Add functionality to set metadata
 - Add functionality to update initrd

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Versions can be overridden with environment variables for matrix testing.
 # Travis will remove Gemfile.lock before installing deps.
 
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.4.0'
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.6.0'
 
 gem 'rake'
 gem 'puppet-lint'
@@ -12,7 +12,6 @@ gem 'rspec-puppet'
 gem 'rspec-system-puppet'
 gem 'rspec-system-serverspec'
 gem 'puppetlabs_spec_helper'
-gem 'puppet-syntax'
 
 # Needed since puppet 2.7 doesn't include hiera
 gem 'hiera' if ENV['PUPPET_VERSION'] =~ /2.7/

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'chartbeat/mdadm'
-version       '0.0.2'
+version       '0.0.3'
 source        'https://github.com/chartbeat-labs/puppet-mdadm'
 author        'chartbeat'
 license       'MIT'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
-require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
-require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppetlabs_spec_helper/rake_tasks'
 require 'rspec-system/rake_task'
 
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
@@ -18,11 +17,9 @@ exclude_paths = [
   "spec/**/*",
 ]
 PuppetLint.configuration.ignore_paths = exclude_paths
-PuppetSyntax.exclude_paths = exclude_paths
 
-desc "Run syntax, lint, and spec tests."
+desc "Run lint and spec tests."
 task :test => [
-  :syntax,
   :lint,
   :spec,
 ]


### PR DESCRIPTION
[skip ci] add support for puppet 3.6.x and bump rev to 0.0.3
