### PR TITLE
Also manage the mdadm cronjob in /etc/cron.daily/

### DIFF
--- a/files/etc_cron_d_mdadm
+++ b/files/etc_cron_d_mdadm
@@ -1,0 +1,12 @@
+#
+# cron.d/mdadm -- schedules periodic redundancy checks of MD devices
+#
+# Copyright © martin f. krafft <madduck@madduck.net>
+# distributed under the terms of the Artistic Licence 2.0
+#
+
+# By default, run at 00:57 on every Sunday, but do nothing unless the day of
+# the month is less than or equal to 7. Thus, only run on the first Sunday of
+# each month. crontab(5) sucks, unfortunately, in this regard; therefore this
+# hack (see #380425).
+57 0 * * 0 root if [ -x /usr/share/mdadm/checkarray ] && [ $(date +\%d) -le 7 ]; then /usr/share/mdadm/checkarray --cron --all --idle --quiet; fi

--- a/files/etc_cron_daily_mdadm
+++ b/files/etc_cron_daily_mdadm
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# cron.daily/mdadm -- daily check that MD devices are functional
+#
+# Copyright © 2008 Paul Slootman <paul@debian.org>
+# distributed under the terms of the Artistic Licence 2.0
+
+# As recommended by the manpage, run
+#      mdadm --monitor --scan --oneshot
+# every day to ensure that any degraded MD devices don't go unnoticed.
+# Email will go to the address specified in /etc/mdadm/mdadm.conf .
+#
+set -eu
+
+MDADM=/sbin/mdadm
+[ -x $MDADM ] || exit 0 # package may be removed but not purged
+
+exec $MDADM --monitor --scan --oneshot

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,9 +4,29 @@
 #
 class mdadm::config {
 
-  if ($mdadm::include_cron) {
-    file { '/etc/cron.d/mdadm' :
-      ensure => 'present',
-    }
+  $cron_ensure = $mdadm::include_cron ? {
+    true  => present,
+    false => absent,
   }
+
+  $cron_daily_ensure = $mdadm::include_cron_daily ? {
+    true  => present,
+    false => absent,
+  }
+
+  file { '/etc/cron.d/mdadm' :
+    ensure => $cron_ensure,
+    owner  => 'root',
+    group  => 'root',
+    source => 'puppet:///modules/mdadm/etc_cron_d_mdadm',
+  }
+
+  file { '/etc/cron.daily/mdadm' :
+    ensure => $cron_daily_ensure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    source => 'puppet:///modules/mdadm/etc_cron_daily_mdadm',
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,12 @@
 #   Boolean. Whether to manage the service or not. Default is true.
 #
 # [*include_cron*]
-#   Boolean. Whether to ensure the mdadm cronjob exists in /etc/cron.d/
+#   Boolean. Whether to put the mdadm cronjob to /etc/cron.d/
+#   /usr/share/mdadm/checkarray --cron --all --idle --quiet
+#
+# [*include_cron_daily*]
+#   Boolean. Whether to put the mdadm cronjob to /etc/cron.daily/
+#   mdadm --monitor --scan --oneshot
 #
 class mdadm (
   $package_name = hiera('mdadm::package_name', $mdadm::params::package_name),
@@ -35,6 +40,8 @@ class mdadm (
   $service_hasstatus = hiera('mdadm::service_hasstatus',
                           $mdadm::params::service_hasstatus),
   $include_cron = hiera('mdadm::include_cron', $mdadm::params::include_cron),
+  $include_cron_daily = hiera('mdadm::include_cron_daily', 
+			  $mdadm::params::include_cron_daily),
 
 ) inherits mdadm::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class mdadm::params {
         $service_hasstatus = true
       }
       $include_cron = true
+      $include_cron_daily = true
     }
     default: {
       fail("${::operatingsystem} not supported")

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -8,15 +8,18 @@ describe 'mdadm', :type => :class do
     }}
 
     context 'with no parameters' do
-      it { should contain_file('/etc/cron.d/mdadm') }
+      it { should contain_file('/etc/cron.d/mdadm').with({'ensure' => 'present'}) }
+      it { should contain_file('/etc/cron.daily/mdadm').with({'ensure' => 'present'}) }
     end
 
     context 'with parameters' do
       let(:params) {{
         :include_cron => false,
+	:include_cron_daily => false,
       }}
 
-      it { should_not contain_file('/etc/cron.d/mdadm') }
+      it { should contain_file('/etc/cron.d/mdadm').with({'ensure' => 'absent'}) }
+      it { should contain_file('/etc/cron.daily/mdadm').with({'ensure' => 'absent'}) }
     end
   end
 end


### PR DESCRIPTION
In Ubuntu 14.04 the mdadm package also contains the cronjob in /etc/cron.daily/.
After this commit both cronjobs will be managed explicitly by puppet.