### PR TITLE
Allowing f2, n2, and o2 (default) parity on RAID10

### DIFF
--- a/lib/puppet/type/mdadm.rb
+++ b/lib/puppet/type/mdadm.rb
@@ -93,9 +93,9 @@ Puppet::Type.newtype(:mdadm) do
   end
 
   newparam(:parity) do
-    desc 'The raid parity. Only applicable to raid5/6'
+    desc 'The raid parity. Only applicable to raid5/6/10'
     newvalues('left-symmetric', 'right-symmetric', 'left-asymmetric',
-              'right-asymmetric')
+              'right-asymmetric', 'f2', 'n2', 'o2')
   end
 
   newparam(:bitmap) do
@@ -149,8 +149,8 @@ Puppet::Type.newtype(:mdadm) do
       raise(Puppet::Error, "Both devices and level are required attributes")
     end
 
-    if self[:parity] and not [5, '5', 'raid5', '6', 6, 'raid6'].include?(self[:level])
-      raise(Puppet::Error, "Parity can only be set on raid5/6")
+    if self[:parity] and not [5, '5', 'raid5', '6', 6, 'raid6', 10, '10', 'raid10'].include?(self[:level])
+      raise(Puppet::Error, "Parity can only be set on raid5/6/10")
     end
   end
 

--- a/manifests/array.pp
+++ b/manifests/array.pp
@@ -28,8 +28,9 @@
 #   Optionally specify the chunksize in kibibytes.
 #
 # [*parity*]
-#   The raid parity. Only applicable to raid5/6  Valid values are
-#   'left-symmetric', 'right-symmetric', 'left-asymmetric', 'right-asymmetric'.
+#   The raid parity. Only applicable to raid5/6/10  Valid values are
+#   'left-symmetric', 'right-symmetric', 'left-asymmetric', 'right-asymmetric',
+#   'f2', 'n2', or 'o2'.
 #
 # [*bitmap*]
 #   Create a bitmap for the array with the given filename.

--- a/spec/unit/puppet/type/mdadm_spec.rb
+++ b/spec/unit/puppet/type/mdadm_spec.rb
@@ -162,7 +162,7 @@ describe Puppet::Type.type(:mdadm) do
                           :parity => 'left-asymmetric',
                           :provider => provider)
     end
-    it { expect { resource }.to raise_error(Puppet::Error, /Parity can only be set on raid5\/6/) }
+    it { expect { resource }.to raise_error(Puppet::Error, /Parity can only be set on raid5\/6\/10/) }
   end
 
   describe 'resource with invalid parity' do
@@ -174,7 +174,7 @@ describe Puppet::Type.type(:mdadm) do
                           :provider => provider)
     end
     it { expect { resource }.to raise_error(Puppet::Error,
-        /Invalid value "foo". Valid values are left-symmetric, right-symmetric, left-asymmetric, right-asymmetric/ ) }
+        /Invalid value "foo". Valid values are left-symmetric, right-symmetric, left-asymmetric, right-asymmetric, f2, n2, o2/ ) }
   end
 
   describe 'when changing the ensure' do


### PR DESCRIPTION
RAID10 should support a parity setting (in this case really meaning the _layout_), of at least "f2", "n2", and "o2", though this should probably be expanded a bit to allow more exotic configurations (meaning integers other than '2'). From the man page for `mdadm`:

              Finally, the layout options for RAID10 are one of 'n', 'o'  or
              'f'  followed  by  a  small number.  The default is 'n2'.  The
              supported options are:

              'n' signals 'near' copies.  Multiple copies of one data  block
              are at similar offsets in different devices.

              'o'  signals  'offset'  copies.   Rather than the chunks being
              duplicated within a stripe, whole stripes are  duplicated  but
              are rotated by one device so duplicate blocks are on different
              devices.  Thus subsequent copies of a block are  in  the  next
              drive, and are one chunk further down.

              'f'  signals 'far' copies (multiple copies have very different
              offsets).  See md(4) for more detail about  'near',  'offset',
              and 'far'.

              The  number  is  the number of copies of each datablock.  2 is
              normal, 3 can be useful.  This number can be at most equal  to
              the  number  of  devices  in  the  array.  It does not need to
              divide evenly into that number (e.g. it is perfectly legal  to
              have  an  'n2'  layout  for  an  array  with  an odd number of
              devices).