### PR TITLE
Unpin rspec-puppet from eletrical fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
-  gem "rspec-puppet", :git => 'https://github.com/electrical/rspec-puppet.git', :ref => '83146c2'
+  gem "rspec-puppet"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "rspec-puppet-facts"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,79 +1,83 @@
-GIT
-  remote: https://github.com/electrical/rspec-puppet.git
-  revision: 83146c2010ee454a2ac1ef38a3fb797a2337915d
-  ref: 83146c2
-  specs:
-    rspec-puppet (2.0.0)
-      rspec
-
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.0)
-    activesupport (4.2.0)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    addressable (2.3.7)
-    autoparse (0.3.3)
-      addressable (>= 2.3.1)
-      extlib (>= 0.9.15)
-      multi_json (>= 1.0.0)
-    aws-sdk (1.63.0)
-      aws-sdk-v1 (= 1.63.0)
-    aws-sdk-v1 (1.63.0)
+    CFPropertyList (2.2.8)
+    addressable (2.4.0)
+    aws-sdk (1.66.0)
+      aws-sdk-v1 (= 1.66.0)
+    aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    backports (3.6.4)
-    beaker (2.5.1)
+    backports (3.6.8)
+    beaker (2.43.0)
       aws-sdk (~> 1.57)
+      beaker-answers (~> 0.0)
+      beaker-hiera (~> 0.0)
+      beaker-pe (~> 0.0)
       docker-api
       fission (~> 0.4)
-      fog (~> 1.25)
-      google-api-client (~> 0.8)
-      hocon (~> 0.0.4)
+      fog (~> 1.25, < 1.35.0)
+      fog-google (~> 0.0.9)
+      google-api-client (~> 0.8, < 0.9.5)
+      hocon (~> 0.1)
       inifile (~> 2.0)
       json (~> 1.8)
+      mime-types (~> 2.99)
       minitest (~> 5.4)
       net-scp (~> 1.2)
       net-ssh (~> 2.9)
+      open_uri_redirections (~> 0.2.1)
       rbvmomi (~> 1.8)
       rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
       unf (~> 0.1)
-    beaker-rspec (5.0.1)
+    beaker-answers (0.5.1)
+      hocon (~> 0.9.5)
+      require_all (~> 1.3.2)
+      stringify-hash (~> 0.0.0)
+    beaker-hiera (0.1.1)
+      stringify-hash (~> 0.0.0)
+    beaker-pe (0.4.0)
+      stringify-hash (~> 0.0.0)
+    beaker-rspec (5.3.0)
       beaker (~> 2.0)
       rspec
       serverspec (~> 2)
       specinfra (~> 2)
     builder (3.2.2)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
-    coderay (1.1.0)
+    coderay (1.1.1)
     diff-lcs (1.2.5)
-    docker-api (1.20.0)
+    docker-api (1.28.0)
       excon (>= 0.38.0)
       json
-    ethon (0.7.3)
+    domain_name (0.5.20160310)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.9.0)
       ffi (>= 1.3.0)
-    excon (0.44.4)
-    extlib (0.9.16)
-    facter (1.7.6)
-    faraday (0.9.1)
+    excon (0.49.0)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    facterdb (0.3.5)
+      facter
+      jgrep
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.9.1)
+    faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.6)
+    ffi (1.9.10)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.28.0)
+    fog (1.34.0)
       fog-atmos
-      fog-aws (~> 0.0)
+      fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.3)
-      fog-ecloud
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (>= 0.0.2)
       fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
       fog-profitbricks
       fog-radosgw (>= 0.0.2)
       fog-riakcs
@@ -90,32 +94,44 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.1.1)
+    fog-aws (0.9.2)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.7.1)
+    fog-brightbox (0.10.1)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.29.0)
+    fog-core (1.40.0)
       builder
-      excon (~> 0.38)
+      excon (~> 0.49)
       formatador (~> 0.2)
-      mime-types
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
-    fog-ecloud (0.0.2)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
       fog-core
       fog-xml
-    fog-json (1.0.0)
-      multi_json (~> 1.0)
-    fog-profitbricks (0.0.1)
+    fog-google (0.0.9)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.0)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.5)
       fog-core
       fog-xml
       nokogiri
-    fog-radosgw (0.0.3)
+    fog-radosgw (0.0.5)
       fog-core (>= 1.21.0)
       fog-json
       fog-xml (>= 0.0.1)
@@ -123,28 +139,28 @@ GEM
       fog-core
       fog-json
       fog-xml
-    fog-sakuracloud (1.0.0)
+    fog-sakuracloud (1.7.5)
       fog-core
       fog-json
-    fog-serverlove (0.1.1)
+    fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-softlayer (0.4.1)
+    fog-softlayer (1.1.1)
       fog-core
       fog-json
-    fog-storm_on_demand (0.1.0)
+    fog-storm_on_demand (0.1.1)
       fog-core
       fog-json
-    fog-terremark (0.0.4)
+    fog-terremark (0.1.0)
       fog-core
       fog-xml
-    fog-vmfusion (0.0.1)
+    fog-vmfusion (0.1.0)
       fission
       fog-core
-    fog-voxel (0.0.2)
+    fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-xml (0.1.1)
+    fog-xml (0.1.2)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
@@ -155,19 +171,27 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (>= 2.7)
       net-http-pipeline
-    google-api-client (0.8.2)
-      activesupport (>= 3.2)
+    google-api-client (0.9.4)
       addressable (~> 2.3)
-      autoparse (~> 0.3)
-      extlib (~> 0.9)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 2.3.0)
+      retriable (~> 2.0)
+      thor (~> 0.19)
+    googleauth (0.5.1)
       faraday (~> 0.9)
-      launchy (~> 2.4)
-      multi_json (~> 1.10)
-      retriable (~> 1.4)
-      signet (~> 0.6)
-    guard (2.12.4)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
+    guard (2.14.0)
       formatador (>= 0.2.4)
-      listen (~> 2.7)
+      listen (>= 2.7, < 4.0)
       lumberjack (~> 1.0)
       nenv (~> 0.1)
       notiffany (~> 0.0)
@@ -179,147 +203,171 @@ GEM
       rake
     hiera (1.3.4)
       json_pure
-    highline (1.7.1)
-    hitimes (1.2.2)
-    hocon (0.0.7)
-    i18n (0.7.0)
+    highline (1.7.8)
+    hocon (0.9.5)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    httpclient (2.8.0)
+    hurley (0.2)
     inflecto (0.0.2)
     inifile (2.0.2)
-    ipaddress (0.8.0)
-    json (1.8.2)
-    json_pure (1.8.2)
-    jwt (1.3.0)
+    ipaddress (0.8.3)
+    jgrep (1.4.1)
+      json
+    json (1.8.3)
+    json_pure (1.8.3)
+    jwt (1.5.4)
     launchy (2.4.3)
       addressable (~> 2.3)
-    listen (2.8.6)
-      celluloid (>= 0.15.2)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    lumberjack (1.0.9)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    little-plugger (1.1.4)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    lumberjack (1.0.10)
+    mcollective-client (2.8.4)
+      json
+      stomp
+      systemu
+    memoist (0.14.0)
     metaclass (0.0.4)
-    metadata-json-lint (0.0.6)
+    metadata-json-lint (0.0.11)
       json
       spdx-licenses (~> 1.0)
     method_source (0.8.2)
-    mime-types (2.4.3)
-    mini_portile (0.6.2)
-    minitest (5.5.1)
+    mime-types (2.99.2)
+    mini_portile2 (2.0.0)
+    minitest (5.9.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.11.0)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
-    nenv (0.2.0)
+    nenv (0.3.0)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
-    netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    notiffany (0.0.6)
+    net-ssh (2.9.4)
+    net-telnet (0.1.1)
+    netrc (0.11.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    notiffany (0.1.0)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    open_uri_redirections (0.2.1)
+    os (0.9.6)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
-    puppet (3.7.4)
+    puppet (3.7.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
-    puppet-blacksmith (3.2.0)
+    puppet-blacksmith (3.3.1)
       puppet (>= 2.7.16)
       rest-client
     puppet-lint (1.1.0)
-    puppet-syntax (2.0.0)
+    puppet-syntax (2.1.0)
       rake
-    puppetlabs_spec_helper (0.9.1)
+    puppetlabs_spec_helper (1.1.1)
       mocha
       puppet-lint
       puppet-syntax
       rake
       rspec-puppet
-    pusher-client (0.6.0)
+    pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    rake (10.4.2)
-    rb-fsevent (0.9.4)
-    rb-inotify (0.9.5)
+    rake (11.1.2)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rbvmomi (1.8.2)
       builder
       nokogiri (>= 1.4.1)
       trollop
-    rest-client (1.7.3)
+    representable (2.3.0)
+      uber (~> 0.0.7)
+    require_all (1.3.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    retriable (1.4.1)
-    rspec (3.2.0)
-      rspec-core (~> 3.2.0)
-      rspec-expectations (~> 3.2.0)
-      rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.1)
-      rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.0)
+    retriable (2.1.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
+      rspec-support (~> 3.4.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.2.1)
+    rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-puppet-facts (0.5.0)
+      rspec-support (~> 3.4.0)
+    rspec-puppet (2.4.0)
+      rspec
+    rspec-puppet-facts (1.6.1)
       facter
+      facterdb (>= 0.3.0)
       json
-    rspec-support (3.2.2)
+      mcollective-client
+      puppet
+    rspec-support (3.4.1)
     rsync (1.0.9)
-    serverspec (2.10.0)
+    ruby_dep (1.3.1)
+    serverspec (2.36.0)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.15)
+      specinfra (~> 2.53)
+    sfl (2.2)
     shellany (0.0.1)
-    signet (0.6.0)
+    signet (0.7.2)
       addressable (~> 2.3)
-      extlib (~> 0.9)
       faraday (~> 0.9)
-      jwt (~> 1.0)
+      jwt (~> 1.5)
       multi_json (~> 1.10)
     slop (3.6.0)
-    spdx-licenses (1.0.0)
-      json
-    specinfra (2.19.0)
+    spdx-licenses (1.1.0)
+    specinfra (2.59.0)
       net-scp
-      net-ssh
+      net-ssh (>= 2.7, < 4.0)
+      net-telnet
+      sfl
+    stomp (1.3.5)
+    stringify-hash (0.0.2)
+    systemu (2.6.5)
     thor (0.19.1)
-    thread_safe (0.3.4)
-    timers (4.0.1)
-      hitimes
-    travis (1.7.5)
-      addressable (~> 2.3)
+    travis (1.8.2)
       backports
       faraday (~> 0.9)
       faraday_middleware (~> 0.9, >= 0.9.1)
       gh (~> 0.13)
       highline (~> 1.6)
       launchy (~> 2.1)
-      pry (~> 0.9, < 0.10)
       pusher-client (~> 0.4)
       typhoeus (~> 0.6, >= 0.6.8)
     travis-lint (2.0.0)
       json
-    trollop (2.1.1)
-    typhoeus (0.7.1)
-      ethon (>= 0.7.1)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+    trollop (2.1.2)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    uber (0.0.15)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
-    vagrant-wrapper (2.0.2)
-    websocket (1.2.1)
+    unf_ext (0.0.7.2)
+    vagrant-wrapper (2.0.3)
+    websocket (1.2.3)
 
 PLATFORMS
   ruby
@@ -333,7 +381,7 @@ DEPENDENCIES
   puppet-blacksmith
   puppetlabs_spec_helper
   rake
-  rspec-puppet!
+  rspec-puppet
   rspec-puppet-facts
   travis
   travis-lint


### PR DESCRIPTION
Tests on travis for 1.9.3 were failing on rspec-puppet bundler installs. Couldn't reproduce on my local computer (I use rbenv instead of rvm) but we should try to reconverge on upstream rspec-puppet anyway.

`bundle exec rake test` pass locally, PR for travis tests.