### PR TITLE
Fix the debian/ubuntu version cutoff used for the mdmonitor service

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,8 +9,11 @@ class mdadm::params {
       $package_name = 'mdadm'
       $package_ensure = 'present'
 
-      # Under systemd, the service is called mdmonitor
-      if ($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemrelease, '16.04') < 0) or ($operatingsystem == 'Debian' and versioncmp($operatingsystemrelease, '9') < 0) {
+      # Under mdadm 3.3.1+ with systemd, the service is called mdmonitor
+      # This means Debian jessie (mdadm 3.3.2)/stretch (mdadm 3.4) and Ubuntu
+      # bionic (mdadm 4.0) for instance use 'mdmonitor' as the service name,
+      # but Ubuntu xenial (mdadm 3.3) and below still use 'mdadm'
+      if ($operatingsystem == 'Ubuntu' and versioncmp($operatingsystemrelease, '16.10') < 0) or ($operatingsystem == 'Debian' and versioncmp($operatingsystemrelease, '8') < 0) {
         $service_name = 'mdadm'
       } else {
         $service_name = 'mdmonitor'

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -57,11 +57,31 @@ describe 'mdadm', :type => :class do
       }
     end
 
-    context 'with systemd based systems' do
+    context 'with an older Ubuntu systemd based system' do
       let(:facts) {{
         :osfamily => 'Debian',
         :operatingsystem => 'Ubuntu',
         :operatingsystemrelease => '16.04',
+      }}
+
+      it { should contain_service('mdadm') }
+    end
+
+    context 'with a newer Ubuntu systemd based system' do
+      let(:facts) {{
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :operatingsystemrelease => '18.04',
+      }}
+
+      it { should contain_service('mdmonitor') }
+    end
+
+    context 'with a older Debian systemd based system' do
+      let(:facts) {{
+        :osfamily => 'Debian',
+        :operatingsystem => 'Debian',
+        :operatingsystemrelease => '8',
       }}
 
       it { should contain_service('mdmonitor') }


### PR DESCRIPTION
After trying out the most recent version of this module on Ubuntu xenial (16.04), I found that it was trying to use the `mdmonitor` service name instead of `mdadm` even though it only has [mdadm version 3.3](https://packages.ubuntu.com/xenial-updates/mdadm) and not 3.3.1 (when [mdmonitor.service was added upstream](https://github.com/neilbrown/mdadm/commit/61c094715836e76b66d7a69adcb6769127b5b77d)). I've gone ahead and updated the version cutoff used (and included Debian jessie in having mdmonitor since it has [version 3.3.2](https://packages.debian.org/jessie/mdadm) available) and made sure that both Debian jessie/stretch and Ubuntu bionic packages have `mdmonitor.service` files included with them.

Should I add something to the `CHANGELOG` too, or would you like to do that part? I also don't really mind much if a new release is made (since we use SHAs to pin modules usually), but others might want that.

Thanks for making this module, it's been great to use so far! :D