### PR TITLE
Fix bug in metadata.json causing it to fail on 4.0 tests

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0 < 6.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
 * For whatever reason, even though the metadata-json-lint package was
   the same, metadata_lint tasks worked for 5.0 and didn't on 4.0.
   It seems that for 4.0, you need to specify the full major.minor.patch
   for semver specifiers.